### PR TITLE
Add username support

### DIFF
--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -5,9 +5,9 @@ const jwt = require('jsonwebtoken');
 // SIGNUP CONTROLLER
 exports.signup = async (req, res) => {
   try {
-    const { name, email, phone, password } = req.body;
+    const { name, username, email, phone, password } = req.body;
 
-    if (!name || !email || !password) {
+    if (!name || !username || !email || !password) {
       return res.status(400).json({ error: 'All required fields must be filled' });
     }
 
@@ -17,7 +17,7 @@ exports.signup = async (req, res) => {
     }
 
     const hashedPassword = await bcrypt.hash(password, 10);
-    const user = await User.create({ name, email, phone, password: hashedPassword });
+    const user = await User.create({ name, username, email, phone, password: hashedPassword });
 
     const token = jwt.sign({ id: user._id }, process.env.JWT_SECRET, { expiresIn: '7d' });
 

--- a/src/pages/auth/Signup.jsx
+++ b/src/pages/auth/Signup.jsx
@@ -6,6 +6,7 @@ export default function Signup() {
   const navigate = useNavigate();
   const [formData, setFormData] = useState({
     name: '',
+    username: '',
     email: '',
     phone: '',
     password: '',
@@ -67,6 +68,7 @@ export default function Signup() {
 
           {[
             { label: 'Name', type: 'text' },
+            { label: 'Username', type: 'text' },
             { label: 'Email', type: 'email' },
             { label: 'Phone', type: 'tel' },
             { label: 'Password', type: 'password' },


### PR DESCRIPTION
## Summary
- collect `username` during signup
- include `username` in backend signup controller

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684baa4a2a188323812bc309608679e6